### PR TITLE
std::atomic use cases.

### DIFF
--- a/Atomic-Types/Makefile
+++ b/Atomic-Types/Makefile
@@ -1,0 +1,38 @@
+# Compiler to use
+CC = g++
+
+# Compiler flags
+CFLAGS = -Wall -Wextra -pedantic -std=c++17
+
+# Source, Object, and Binary directories
+SRCDIR = ./
+OBJDIR = ~/Desktop/Pranshu/obj
+BINDIR = ~/Desktop/Pranshu/bin
+
+# Target source file
+TARGET ?= main.cpp  # Default to main.cpp if no TARGET is specified
+
+# Generate object file name from target source file
+TARGET_NAME = $(basename $(notdir $(TARGET)))
+OBJECTS = $(OBJDIR)/$(TARGET_NAME).o
+EXECUTABLE = $(BINDIR)/$(TARGET_NAME)
+
+# Phony targets to avoid conflicts with files of the same name
+.PHONY: all clean
+
+# Default target: build the executable from the specified TARGET
+all: $(EXECUTABLE)
+
+# Link object file to create the executable
+$(EXECUTABLE): $(OBJECTS)
+	@mkdir -p $(BINDIR)
+	$(CC) $(CFLAGS) $^ -o $@
+
+# Compile the target source file to object file
+$(OBJDIR)/%.o: $(SRCDIR)/%.cpp
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Clean up build artifacts
+clean:
+	@rm -rf $(OBJDIR) $(BINDIR)

--- a/Atomic-Types/atomic_counter.cpp
+++ b/Atomic-Types/atomic_counter.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <thread>
+#include <atomic>
+
+/**
+ * Now the counter value is not pre-fetched by different thread cores
+ * and the value is updated atomically, by flushing the store buffer.
+ * 
+ * This should only be used when datatype is trivially copyable and
+ * the operation is simple. It is faster than lock-based synchronization.
+ */
+std::atomic<int> counter{0};
+
+void increment_counter() {
+    for(int i = 0 ; i < 1000 ; i++) {
+        counter++;
+    }
+}
+
+int main() {
+    std::vector<std::thread> threads;
+    for(int i = 0 ; i < 10 ; i++) {
+        threads.push_back(std::thread(increment_counter));
+    }
+    for(auto& thread: threads) {
+        thread.join();
+    }
+    std::cout << "Counter value: " << counter << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/Atomic-Types/atomic_singleton.cpp
+++ b/Atomic-Types/atomic_singleton.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <thread>
+#include <atomic>
+#include <mutex>
+
+class Singleton {
+    static std::atomic<Singleton*> instance;
+    static std::mutex init_mutex;
+    public:
+        static Singleton* getInstance() {
+            auto ptr = instance.load(std::memory_order_acquire);
+            if(ptr == nullptr) {
+                std::lock_guard<std::mutex> lock(init_mutex);
+                ptr = instance.load(std::memory_order_acquire);
+                if (ptr == nullptr) {
+                    ptr = new Singleton();
+                    instance.store(ptr, std::memory_order_release);
+                }
+            }
+            return ptr;
+        }
+
+        Singleton() {
+            std::cout << "Singleton instance created" << std::endl;
+        }
+        ~Singleton() = default;
+};
+
+void task() {
+    [[maybe_unused]] auto instance = Singleton::getInstance();
+}
+
+std::atomic<Singleton*> Singleton::instance{nullptr};
+std::mutex Singleton::init_mutex;
+
+int main() {
+    std::vector<std::thread> thrs;
+    for(int i = 0 ; i < 10 ; i++) {
+        thrs.push_back(std::thread(task));
+    }
+    for(auto& thr: thrs) {
+        thr.join();
+    }
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
When working on the concurrency of threads, one must ensure the results that a multi-threaded system brings out to the world always follow the ACID properties.

To follow the Atomicity we have the std::atomic and std::atomic_bool types of containers that ensure a single operation is executing on them uninterrupted until its completion.

But there are some limitations to this atomic template class,
- It works only with trivially copyable containers. (like pointers, int, etc but not the Class objects.)

They can be a basis for lock-free programming, which again is a very vicious approach if gone wrong.